### PR TITLE
Fix translation-error in test

### DIFF
--- a/custom_components/plugwise_usb/strings.json
+++ b/custom_components/plugwise_usb/strings.json
@@ -15,13 +15,11 @@
       }
     },
     "error": {
+      "already_configured": "This device is already configured",
       "cannot_connect": "Failed to connect",
       "network_down": "Plugwise Zigbee network is down",
       "network_timeout": "Network communication timeout",
       "stick_init": "Initialization of Plugwise USB-stick failed"
-    },
-    "abort": {
-      "already_configured": "This device is already configured"
     }
   },
   "services": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new error message for the Plugwise USB component to indicate when a device is already configured.
- **Bug Fixes**
	- Removed redundancy by eliminating the previous error message from the abort section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->