### PR TITLE
Fix error in Number platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Versions from 0.4x
 
+### v0.50.1
+
+- Fix error in Number platform
+
 ### v0.50.0
 
 - Link to plugwise_usb v0.40.0 - fully reworked [async version](https://github.com/plugwise/python-plugwise-usb/releases/tag/v0.40.0)

--- a/custom_components/plugwise_usb/number.py
+++ b/custom_components/plugwise_usb/number.py
@@ -12,7 +12,7 @@ from homeassistant.components.number import (
     NumberEntityDescription,
 )
 from homeassistant.const import EntityCategory, Platform, UnitOfTime
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from plugwise_usb.api import NodeEvent, NodeFeature
 
@@ -100,6 +100,7 @@ NUMBER_TYPES: tuple[PlugwiseNumberEntityDescription, ...] = (
 
 
 async def async_setup_entry(
+    _hass: HomeAssistant,
     config_entry: PlugwiseUSBConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plugwise_usb-beta"
-version = "0.50.0"
+version = "0.50.1"
 description = "Plugwise USB custom_component (BETA)"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
Solves:
```
2025-05-26 19:16:39.219 ERROR (MainThread) [homeassistant.components.number] Error while setting up plugwise_usb platform for number: async_setup_entry() takes 2 positional arguments but 3 were given
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 377, in _async_setup_platform
    awaitable = async_create_setup_awaitable()
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 345, in async_create_setup_awaitable
    return platform.async_setup_entry(  # type: ignore[union-attr]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        self.hass, config_entry, self._async_schedule_add_entities_for_entry
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
TypeError: async_setup_entry() takes 2 positional arguments but 3 were given
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an error in the Number platform to improve stability.

- **Chores**
  - Updated project version to 0.50.1.
  - Added a new changelog entry for this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->