### PR TITLE
remove non-existing S320 from test listing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,6 @@ lint.select = [
     "S317",  # suspicious-xml-sax-usage
     "S318",  # suspicious-xml-mini-dom-usage
     "S319",  # suspicious-xml-pull-dom-usage
-    "S320",  # suspicious-xmle-tree-usage
     "S601",  # paramiko-call
     "S602",  # subprocess-popen-with-shell-equals-true
     "S604",  # call-with-shell-equals-true


### PR DESCRIPTION
Fix for ruff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated linting configuration by removing the "suspicious-xmle-tree-usage" rule from the selected checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->