### PR TITLE
Show energy-reset button for Plus devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Versions from 0.4x
 
+### v0.55.1 - 2025-06-22
+
+- Show energy-reset button for Plus devices via plugwise_usb [v0.44.5](https://github.com/plugwise/python-plugwise-usb/releases/tag/v0.44.5)
+
 ### v0.55.0 - 2025-06-22
 
 - Implement an energy-reset button for energy devices that resets/restarts the energy-collection on the device overwriting the existing data

--- a/custom_components/plugwise_usb/manifest.json
+++ b/custom_components/plugwise_usb/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["plugwise_usb"],
-  "requirements": ["plugwise-usb==0.44.4"],
-  "version": "0.55.0"
+  "requirements": ["plugwise-usb==0.44.5"],
+  "version": "0.55.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plugwise_usb-beta"
-version = "0.55.0"
+version = "0.55.1"
 description = "Plugwise USB custom_component (BETA)"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,4 +4,4 @@ pytest-asyncio
 pytest-homeassistant-custom-component
 aiousbwatcher
 # From our manifest.json for our custom component
-plugwise-usb @ https://files.pythonhosted.org/packages/5d/51/5e1a7f12954bdf0cbed1a460ec1700802e9d92015735c93a6e755f639c95/plugwise_usb-0.44.4.tar.gz
+plugwise-usb @ https://files.pythonhosted.org/packages/b1/82/66c42393fa98e94951b106ca41b46b03e20f8c5d29df1ce043cfd586e5b5/plugwise_usb-0.44.5.tar.gz


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an energy-reset button display for Plus devices using the plugwise_usb integration.

- **Chores**
  - Updated plugwise_usb dependency to version 0.44.5.
  - Incremented integration and project version to 0.55.1.
  - Updated test requirements to use the latest plugwise-usb package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->