### PR TITLE
enable entity creation for non-initialized circles (e.g. unreachable)

### DIFF
--- a/custom_components/plugwise_usb/coordinator.py
+++ b/custom_components/plugwise_usb/coordinator.py
@@ -69,7 +69,6 @@ class PlugwiseUSBDataUpdateCoordinator(DataUpdateCoordinator):
         # Only unique features
         freq_features = Counter(self.async_contexts())
         features = tuple(freq_features.keys())
-
         try:
             states = await self.node.get_state(features)
         except StickError as err:
@@ -81,6 +80,7 @@ class PlugwiseUSBDataUpdateCoordinator(DataUpdateCoordinator):
 
         if (
             not self.node.node_info.is_battery_powered
+            and self.node.initialized
             and not states[NodeFeature.AVAILABLE].state
         ):
             raise UpdateFailed("Device is not responding")


### PR DESCRIPTION
If a node was loaded but still offline, the update on instantiation of the entities would fail except for battery operated devices.
Now a check is added to see if the node has been initialized, otherwise the entities are created and placed on unavailable.