### PR TITLE
prevent multiple subscriptions to the same NodeFeature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### v0.55.4 - 2025-07-08
 
-- PR [280](https://github.com/plugwise/plugwise_usb-beta/pull/280): Prevent multiple NodeFeature subscriptions 
+- PR [280](https://github.com/plugwise/plugwise_usb-beta/pull/280): Prevent multiple NodeFeature subscriptions
 
 ### v0.55.3 - 2025-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Versions from 0.4x
 
+### v0.55.4 - 2025-07-08
+
+- PR [280](https://github.com/plugwise/plugwise_usb-beta/pull/280): Prevent multiple NodeFeature subscriptions 
+
 ### v0.55.3 - 2025-07-08
 
 - Bump plugwise to [v0.44.7](https://github.com/plugwise/python-plugwise-usb/releases/tag/v0.44.7)

--- a/custom_components/plugwise_usb/__init__.py
+++ b/custom_components/plugwise_usb/__init__.py
@@ -163,6 +163,8 @@ async def async_unload_entry(
 ) -> bool:
     """Unload the Plugwise USB stick connection."""
     config_entry.runtime_data[UNSUBSCRIBE_DISCOVERY]()
+    for coordinator in config_entry.runtime_data[NODES].values():
+        coordinator.unsubscribe_all_nodefeatures()
     unload = await hass.config_entries.async_unload_platforms(
         config_entry, PLUGWISE_USB_PLATFORMS
     )

--- a/custom_components/plugwise_usb/coordinator.py
+++ b/custom_components/plugwise_usb/coordinator.py
@@ -116,7 +116,7 @@ class PlugwiseUSBDataUpdateCoordinator(DataUpdateCoordinator):
     async def unsubscribe_all_nodefeatures(self) -> None:
         """Unsubscribe to updates."""
         for unsubscribe_push_event in self.unsubscribe_push_events:
-            if unsubscribe_push_event is not None
+            if unsubscribe_push_event is not None:
                 unsubscribe_push_event()
         self.unsubscribe_push_events.clear()
         self.subscribed_nodefeatures.clear()

--- a/custom_components/plugwise_usb/coordinator.py
+++ b/custom_components/plugwise_usb/coordinator.py
@@ -37,8 +37,9 @@ class PlugwiseUSBDataUpdateCoordinator(DataUpdateCoordinator):
     ) -> None:
         """Initialize Plugwise USB data update coordinator."""
         self.node = node
-        self.subscribed_nodefeatures: list[NodeFeature,...] = []
+        self.subscribed_nodefeatures: list[NodeFeature] = []
         self._subscribe_to_feature_fn = self.node.subscribe_to_feature_update
+        self.unsubscribe_push_events: Callable[[], None] | None = None
         if node.node_info.is_battery_powered:
             _LOGGER.debug("Create battery powered DUC for %s", node.mac)
             super().__init__(

--- a/custom_components/plugwise_usb/coordinator.py
+++ b/custom_components/plugwise_usb/coordinator.py
@@ -115,7 +115,7 @@ class PlugwiseUSBDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def unsubscribe_all_nodefeatures(self) -> None:
         """Unsubscribe to updates."""
-        for unsubscribe_push_even in self.unsubscribe_push_events:
+        for unsubscribe_push_event in self.unsubscribe_push_events:
             self.unsubscribe_push_events.pop(self.unsubscribe_push_event)
             self.unsubscribe_push_event()
         self.subscribed_nodefeatures = []

--- a/custom_components/plugwise_usb/coordinator.py
+++ b/custom_components/plugwise_usb/coordinator.py
@@ -116,7 +116,8 @@ class PlugwiseUSBDataUpdateCoordinator(DataUpdateCoordinator):
     async def unsubscribe_all_nodefeatures(self) -> None:
         """Unsubscribe to updates."""
         for unsubscribe_push_event in self.unsubscribe_push_events:
-            self.unsubscribe_push_events.pop(unsubscribe_push_event)
-            unsubscribe_push_event()
-        self.subscribed_nodefeatures = []
+            if unsubscribe_push_event is not None
+                unsubscribe_push_event()
+        self.unsubscribe_push_events.clear()
+        self.subscribed_nodefeatures.clear()
 

--- a/custom_components/plugwise_usb/coordinator.py
+++ b/custom_components/plugwise_usb/coordinator.py
@@ -116,7 +116,7 @@ class PlugwiseUSBDataUpdateCoordinator(DataUpdateCoordinator):
     async def unsubscribe_all_nodefeatures(self) -> None:
         """Unsubscribe to updates."""
         for unsubscribe_push_event in self.unsubscribe_push_events:
-            self.unsubscribe_push_events.pop(self.unsubscribe_push_event)
-            self.unsubscribe_push_event()
+            self.unsubscribe_push_events.pop(unsubscribe_push_event)
+            unsubscribe_push_event()
         self.subscribed_nodefeatures = []
 

--- a/custom_components/plugwise_usb/coordinator.py
+++ b/custom_components/plugwise_usb/coordinator.py
@@ -114,7 +114,7 @@ class PlugwiseUSBDataUpdateCoordinator(DataUpdateCoordinator):
         )
 
     async def unsubscribe_all_nodefeatures(self) -> None:
-        "Unsubscribe to updates."
+        """Unsubscribe to updates."""
         for unsubscribe_push_even in self.unsubscribe_push_events:
             self.unsubscribe_push_events.pop(self.unsubscribe_push_event)
             self.unsubscribe_push_event()

--- a/custom_components/plugwise_usb/entity.py
+++ b/custom_components/plugwise_usb/entity.py
@@ -72,5 +72,4 @@ class PlugwiseUSBEntity(CoordinatorEntity):
 
     async def async_will_remove_from_hass(self):
         """Unsubscribe to updates."""
-        await self.node_duc.unsubscribe_all_nodefeatures()
         await super().async_will_remove_from_hass()

--- a/custom_components/plugwise_usb/manifest.json
+++ b/custom_components/plugwise_usb/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "loggers": ["plugwise_usb"],
   "requirements": ["plugwise-usb==0.44.7"],
-  "version": "0.55.3"
+  "version": "0.55.4"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plugwise_usb-beta"
-version = "0.55.3"
+version = "0.55.4"
 description = "Plugwise USB custom_component (BETA)"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
Switch events would get fired 4x because after subscription to NodeFeature.SWITCH for each event entity, the callback would go to all 4 subscription and then each got propagated again to all 4 entities.
Similar issues existed for other entities, but there the effect was not visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for real-time, push-based updates for specific device features, enabling faster and more efficient data updates.

* **Refactor**
  * Centralized push event subscription management to improve maintainability and reliability by delegating it to the coordinator.
  * Simplified entity lifecycle by removing direct subscription handling and relying on the coordinator for update management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->