### PR TITLE
Fix wrong node_duc.name to node_duc.node.name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Versions from 0.4x
 
+### Ongoing
+
+- Correct logger-messages with `node_duc.node.name`
+
 ### v0.55.8 - 20250-8-15
 
 - Energy-cache-related improvements via plugwise_usb [v0.44.11](https://github.com/plugwise/python-plugwise-usb/releases/tag/v0.44.11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Correct logger-messages with `node_duc.node.name`
 
-### v0.55.8 - 20250-8-15
+### v0.55.8 - 2025-08-15
 
 - Energy-cache-related improvements via plugwise_usb [v0.44.11](https://github.com/plugwise/python-plugwise-usb/releases/tag/v0.44.11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Ongoing
 
-- Correct logger-messages with `node_duc.node.name`
+- Shorten/correct logger-messages to use `node_duc.node.name`
 
 ### v0.55.8 - 2025-08-15
 

--- a/custom_components/plugwise_usb/binary_sensor.py
+++ b/custom_components/plugwise_usb/binary_sensor.py
@@ -60,7 +60,7 @@ async def async_setup_entry(
         entities: list[PlugwiseUSBEntity] = []
         if (node_duc := config_entry.runtime_data[NODES].get(mac)) is not None:
             _LOGGER.debug(
-                "Add binary_sensor entities for %s | duc=%s", mac, node_duc.node.name
+                "Add binary_sensor entities for node %s", node_duc.node.name
             )
             entities.extend(
                 [

--- a/custom_components/plugwise_usb/binary_sensor.py
+++ b/custom_components/plugwise_usb/binary_sensor.py
@@ -60,7 +60,7 @@ async def async_setup_entry(
         entities: list[PlugwiseUSBEntity] = []
         if (node_duc := config_entry.runtime_data[NODES].get(mac)) is not None:
             _LOGGER.debug(
-                "Add binary_sensor entities for %s | duc=%s", mac, node_duc.name
+                "Add binary_sensor entities for %s | duc=%s", mac, node_duc.node.name
             )
             entities.extend(
                 [

--- a/custom_components/plugwise_usb/button.py
+++ b/custom_components/plugwise_usb/button.py
@@ -62,7 +62,7 @@ async def async_setup_entry(
             return
         entities: list[PlugwiseUSBEntity] = []
         if (node_duc := config_entry.runtime_data[NODES].get(mac)) is not None:
-            _LOGGER.debug("Add button entities for %s | duc=%s", mac, node_duc.node.name)
+            _LOGGER.debug("Add button entities for node %s", node_duc.node.name)
             entities.extend(
                 [
                     PlugwiseUSBButtonEntity(node_duc, entity_description)

--- a/custom_components/plugwise_usb/button.py
+++ b/custom_components/plugwise_usb/button.py
@@ -62,7 +62,7 @@ async def async_setup_entry(
             return
         entities: list[PlugwiseUSBEntity] = []
         if (node_duc := config_entry.runtime_data[NODES].get(mac)) is not None:
-            _LOGGER.debug("Add button entities for %s | duc=%s", mac, node_duc.name)
+            _LOGGER.debug("Add button entities for %s | duc=%s", mac, node_duc.node.name)
             entities.extend(
                 [
                     PlugwiseUSBButtonEntity(node_duc, entity_description)

--- a/custom_components/plugwise_usb/event.py
+++ b/custom_components/plugwise_usb/event.py
@@ -83,7 +83,7 @@ async def async_setup_entry(
             return
         entities: list[PlugwiseUSBEntity] = []
         if (node_duc := config_entry.runtime_data[NODES].get(mac)) is not None:
-            _LOGGER.debug("Add event entities for %s | duc=%s", mac, node_duc.name)
+            _LOGGER.debug("Add event entities for %s | duc=%s", mac, node_duc.node.name)
             entities.extend(
                 [
                     PlugwiseUSBEventEntity(node_duc, entity_description)

--- a/custom_components/plugwise_usb/event.py
+++ b/custom_components/plugwise_usb/event.py
@@ -83,7 +83,7 @@ async def async_setup_entry(
             return
         entities: list[PlugwiseUSBEntity] = []
         if (node_duc := config_entry.runtime_data[NODES].get(mac)) is not None:
-            _LOGGER.debug("Add event entities for %s | duc=%s", mac, node_duc.node.name)
+            _LOGGER.debug("Add event entities for node %s", node_duc.node.name)
             entities.extend(
                 [
                     PlugwiseUSBEventEntity(node_duc, entity_description)

--- a/custom_components/plugwise_usb/number.py
+++ b/custom_components/plugwise_usb/number.py
@@ -113,7 +113,7 @@ async def async_setup_entry(
             return
         entities: list[PlugwiseUSBEntity] = []
         if (node_duc := config_entry.runtime_data[NODES].get(mac)) is not None:
-            _LOGGER.debug("Add number entities for %s | duc=%s", mac, node_duc.node.name)
+            _LOGGER.debug("Add number entities for node %s", node_duc.node.name)
             entities.extend(
                 [
                     PlugwiseUSBNumberEntity(node_duc, entity_description)

--- a/custom_components/plugwise_usb/number.py
+++ b/custom_components/plugwise_usb/number.py
@@ -113,7 +113,7 @@ async def async_setup_entry(
             return
         entities: list[PlugwiseUSBEntity] = []
         if (node_duc := config_entry.runtime_data[NODES].get(mac)) is not None:
-            _LOGGER.debug("Add number entities for %s | duc=%s", mac, node_duc.name)
+            _LOGGER.debug("Add number entities for %s | duc=%s", mac, node_duc.node.name)
             entities.extend(
                 [
                     PlugwiseUSBNumberEntity(node_duc, entity_description)

--- a/custom_components/plugwise_usb/sensor.py
+++ b/custom_components/plugwise_usb/sensor.py
@@ -177,7 +177,7 @@ async def async_setup_entry(
             return
         entities: list[PlugwiseUSBEntity] = []
         if (node_duc := config_entry.runtime_data[NODES].get(mac)) is not None:
-            _LOGGER.debug("Add sensor entities for %s | duc=%s", mac, node_duc.name)
+            _LOGGER.debug("Add sensor entities for %s | duc=%s", mac, node_duc.node.name)
             entities.extend(
                 [
                     PlugwiseUSBSensorEntity(node_duc, entity_description)

--- a/custom_components/plugwise_usb/sensor.py
+++ b/custom_components/plugwise_usb/sensor.py
@@ -177,7 +177,7 @@ async def async_setup_entry(
             return
         entities: list[PlugwiseUSBEntity] = []
         if (node_duc := config_entry.runtime_data[NODES].get(mac)) is not None:
-            _LOGGER.debug("Add sensor entities for %s | duc=%s", mac, node_duc.node.name)
+            _LOGGER.debug("Add sensor entities for node %s", node_duc.node.name)
             entities.extend(
                 [
                     PlugwiseUSBSensorEntity(node_duc, entity_description)

--- a/custom_components/plugwise_usb/switch.py
+++ b/custom_components/plugwise_usb/switch.py
@@ -86,7 +86,7 @@ async def async_setup_entry(
             return
         entities: list[PlugwiseUSBEntity] = []
         if (node_duc := config_entry.runtime_data[NODES].get(mac)) is not None:
-            _LOGGER.debug("Add switch entities for %s | duc=%s", mac, node_duc.name)
+            _LOGGER.debug("Add switch entities for %s | duc=%s", mac, node_duc.node.name)
             entities.extend(
                 [
                     PlugwiseUSBSwitchEntity(node_duc, entity_description)

--- a/custom_components/plugwise_usb/switch.py
+++ b/custom_components/plugwise_usb/switch.py
@@ -86,7 +86,7 @@ async def async_setup_entry(
             return
         entities: list[PlugwiseUSBEntity] = []
         if (node_duc := config_entry.runtime_data[NODES].get(mac)) is not None:
-            _LOGGER.debug("Add switch entities for %s | duc=%s", mac, node_duc.node.name)
+            _LOGGER.debug("Add switch entities for node %s", node_duc.node.name)
             entities.extend(
                 [
                     PlugwiseUSBSwitchEntity(node_duc, entity_description)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Fixed debug logging so device-related entities (binary sensors, buttons, events, numbers, sensors, switches) report the correct node name, improving logs and troubleshooting.

- Documentation
  - Added an “Ongoing” subsection under “Versions from 0.4x” in the changelog and documented the corrected logger messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->