### PR TITLE
Enable energy_reset buttons for all non-plus energy devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Versions from 0.4x
 
 ### Ongoing
+
 - Enable energy-reset buttons for all non-plus devices
 
 - Shorten/correct logger-messages to use `node_duc.node.name`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Ongoing
 
-- Enable energy-reset buttons for all non-plus devices
+- Fix disabled buttons for all non-plus devices
 
 - Shorten/correct logger-messages to use `node_duc.node.name`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -321,7 +321,7 @@
 ### MAY 2022 [0.23.2]
 
 - Smile bugfix: fixing [plugwise module 192](https://github.com/plugwise/python-plugwise/issues/192) and [Core Issue 72305](https://github.com/home-assistant/core/issues/72305)
-  via plugwise module [v0.18.5)[https://github.com/plugwise/python-plugwise/releases/tag/v0.18.5]
+  via plugwise module [v0.18.5](https://github.com/plugwise/python-plugwise/releases/tag/v0.18.5)
 
 ### MAY 2022 [0.23.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Ongoing
 
 - Fix disabled buttons for all non-plus devices
-
 - Shorten/correct logger-messages to use `node_duc.node.name`
 
 ### v0.55.8 - 2025-08-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Versions from 0.4x
 
 ### Ongoing
+- Enable energy-reset buttons for all non-plus devices
 
 - Shorten/correct logger-messages to use `node_duc.node.name`
 

--- a/custom_components/plugwise_usb/button.py
+++ b/custom_components/plugwise_usb/button.py
@@ -10,7 +10,7 @@ from plugwise_usb.api import NodeEvent, NodeFeature
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.const import EntityCategory, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import NODES, STICK, UNSUB_NODE_LOADED
@@ -111,6 +111,10 @@ class PlugwiseUSBButtonEntity(PlugwiseUSBEntity, ButtonEntity):
         self.async_button_fn = getattr(
             node_duc.node, entity_description.async_button_fn
         )
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
 
     async def async_press(self) -> None:
         """Button was pressed."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CHANGELOG: added an "Ongoing" note for 0.4x about fixing disabled buttons on non-plus devices and corrected a broken Markdown link.
* **Chores**
  * Internal maintenance of button handling for the plugwise USB integration; no user-visible functional changes in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->