### PR TITLE
Fix for #312, link to plugwise_usb v0.44.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Ongoing
 
 - Fix #312 via PR [324](https://github.com/plugwise/plugwise_usb-beta/pull/324)
+- Link to plugwise_usb [v0.44.14](https://github.com/plugwise/python-plugwise-usb/releases/tag/v0.44.14)
 
 ### v0.55.10 - 2025-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Versions from 0.4x
 
+### Ongoing
+
+- Fix #312 via PR [324](https://github.com/plugwise/plugwise_usb-beta/pull/324)
+
 ### v0.55.10 - 2025-08-29
 
 - Final fix for unavailable buttons via plugwise_usb [v0.44.13](https://github.com/plugwise/python-plugwise-usb/releases/tag/v0.44.13)

--- a/custom_components/plugwise_usb/__init__.py
+++ b/custom_components/plugwise_usb/__init__.py
@@ -189,8 +189,8 @@ async def async_remove_config_entry_device(
         mac = identifier[1]
         try:
             await api_stick.unregister_node(mac)
-        except NodeError:
-            _LOGGER.warning("Plugwise node %s unregistering failed with NodeError", mac)
+        except NodeError as exc:
+            _LOGGER.warning(f"Plugwise node %s unregistering failed: {exc}", mac)
             return True # Must return True for device_registry removal to happen!
 
         _LOGGER.debug("Plugwise device %s successfully removed", mac)

--- a/custom_components/plugwise_usb/__init__.py
+++ b/custom_components/plugwise_usb/__init__.py
@@ -179,6 +179,7 @@ async def async_remove_config_entry_device(
 ) -> bool:
     """Remove a config entry from a device."""
     api_stick = config_entry.runtime_data[STICK]
+    mac = None
     removable = False
     for identifier in device_entry.identifiers:
         if (

--- a/custom_components/plugwise_usb/__init__.py
+++ b/custom_components/plugwise_usb/__init__.py
@@ -179,14 +179,16 @@ async def async_remove_config_entry_device(
 ) -> bool:
     """Remove a config entry from a device."""
     api_stick = config_entry.runtime_data[STICK]
-    removable = not any(
-        identifier
-        for identifier in device_entry.identifiers
-        if identifier[0] == DOMAIN
-        and identifier[1] in (str(api_stick.mac_stick), str(api_stick.mac_coordinator))
-    )
+    removable = False
+    for identifier in device_entry.identifiers:
+        if (
+            identifier[0] == DOMAIN
+            and (mac := identifier[1] in (str(api_stick.mac_stick), str(api_stick.mac_coordinator)))
+        ):
+            removable = True
+            break
+
     if removable:
-        mac = identifier[1]
         try:
             await api_stick.unregister_node(mac)
         except NodeError as exc:

--- a/custom_components/plugwise_usb/__init__.py
+++ b/custom_components/plugwise_usb/__init__.py
@@ -192,7 +192,7 @@ async def async_remove_config_entry_device(
         try:
             await api_stick.unregister_node(mac)
         except NodeError as exc:
-            _LOGGER.warning(f"Plugwise node %s unregistering failed: {exc}", mac)
+            _LOGGER.warning("Plugwise node %s unregistering failed: %s", mac, exc)
             return True # Must return True for device_registry removal to happen!
 
         _LOGGER.debug("Plugwise device %s successfully removed", mac)

--- a/custom_components/plugwise_usb/__init__.py
+++ b/custom_components/plugwise_usb/__init__.py
@@ -183,8 +183,9 @@ async def async_remove_config_entry_device(
     for identifier in device_entry.identifiers:
         if (
             identifier[0] == DOMAIN
-            and (mac := identifier[1] in (str(api_stick.mac_stick), str(api_stick.mac_coordinator)))
+            and identifier[1] not in (str(api_stick.mac_stick), str(api_stick.mac_coordinator))
         ):
+            mac = identifier[1]
             removable = True
             break
 

--- a/custom_components/plugwise_usb/__init__.py
+++ b/custom_components/plugwise_usb/__init__.py
@@ -190,8 +190,8 @@ async def async_remove_config_entry_device(
         try:
             await api_stick.unregister_node(mac)
         except NodeError:
-            _LOGGER.error("Plugwise device %s removal failed with NodeError", mac)
-            return False
+            _LOGGER.warning("Plugwise node %s unregistering failed with NodeError", mac)
+            return True # Must return True for device_registry removal to happen!
 
         _LOGGER.debug("Plugwise device %s successfully removed", mac)
         return True

--- a/custom_components/plugwise_usb/__init__.py
+++ b/custom_components/plugwise_usb/__init__.py
@@ -186,7 +186,7 @@ async def async_remove_config_entry_device(
         and identifier[1] in (str(api_stick.mac_stick), str(api_stick.mac_coordinator))
     )
     if removable:
-        mac = device_entry.serial_number
+        mac = identifier[1]
         try:
             await api_stick.unregister_node(mac)
         except NodeError:

--- a/custom_components/plugwise_usb/manifest.json
+++ b/custom_components/plugwise_usb/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/plugwise/python-plugwise-usb/issues",
   "loggers": ["plugwise_usb"],
-  "requirements": ["plugwise-usb==0.44.13"],
+  "requirements": ["plugwise-usb==0.44.14"],
   "version": "0.55.11"
 }

--- a/custom_components/plugwise_usb/manifest.json
+++ b/custom_components/plugwise_usb/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/plugwise/python-plugwise-usb/issues",
   "loggers": ["plugwise_usb"],
   "requirements": ["plugwise-usb==0.44.14"],
-  "version": "0.55.12a1"
+  "version": "0.55.12"
 }

--- a/custom_components/plugwise_usb/manifest.json
+++ b/custom_components/plugwise_usb/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/plugwise/python-plugwise-usb/issues",
   "loggers": ["plugwise_usb"],
   "requirements": ["plugwise-usb==0.44.14"],
-  "version": "0.55.12a0"
+  "version": "0.55.12a1"
 }

--- a/custom_components/plugwise_usb/manifest.json
+++ b/custom_components/plugwise_usb/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/plugwise/python-plugwise-usb/issues",
   "loggers": ["plugwise_usb"],
   "requirements": ["plugwise-usb==0.44.14"],
-  "version": "0.55.11"
+  "version": "0.55.12a0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plugwise_usb-beta"
-version = "0.55.11"
+version = "0.55.12"
 description = "Plugwise USB custom_component (BETA)"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
This should fix the failure of deleting a dead device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device removal flow and error handling so unregistering proceeds more gracefully and issues are logged with reduced severity.

* **Chores**
  * Bumped plugwise-usb dependency to v0.44.14 and updated package version to v0.55.12.

* **Documentation**
  * Added an "Ongoing" subsection to the changelog linking the recent fix and the upstream v0.44.14 release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->