### PR TITLE
Improve no Plus-device paired raise message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Ongoing
 
-- Improve raise-message for no paired Plus-device via PR[]()
+- Improve raise-message for no paired Plus-device, via PR[#399](https://github.com/plugwise/plugwise_usb-beta/pull/399)
 
 ## v0.59.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Ongoing
+
+- Improve raise-message for no paired Plus-device via PR[]()
+
 ## v0.59.3
 
 - General environment and code updates, improve (test)files structure

--- a/custom_components/plugwise_usb/__init__.py
+++ b/custom_components/plugwise_usb/__init__.py
@@ -101,9 +101,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: PlugwiseUSBConfig
     _LOGGER.info("Start to discover the Plugwise network coordinator (Circle+)")
     try:
         await api_stick.discover_coordinator(load=False)
-    except StickError as exc:
-        await api_stick.disconnect()
-        raise ConfigEntryNotReady("Failed to connect to Circle+") from exc
+    except StickError: # as exc:
+        # await api_stick.disconnect()
+        # raise ConfigEntryNotReady("Failed to connect to Circle+") from exc
+        _LOGGER.warning("Failed to connect to Circle+")
 
     # Load platforms to allow them to register for node events
     await hass.config_entries.async_forward_entry_setups(

--- a/custom_components/plugwise_usb/__init__.py
+++ b/custom_components/plugwise_usb/__init__.py
@@ -101,10 +101,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: PlugwiseUSBConfig
     _LOGGER.info("Start to discover the Plugwise network coordinator (Circle+)")
     try:
         await api_stick.discover_coordinator(load=False)
-    except StickError: # as exc:
-        # await api_stick.disconnect()
-        # raise ConfigEntryNotReady("Failed to connect to Circle+") from exc
-        _LOGGER.warning("Failed to connect to Circle+")
+    except StickError as exc:
+        await api_stick.disconnect()
+        raise ConfigEntryNotReady("No connected Plus-device found, pair with one first e.g. via Source") from exc
 
     # Load platforms to allow them to register for node events
     await hass.config_entries.async_forward_entry_setups(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the connection error message shown when no paired Plus-device is found, including guidance to pair a device before continuing.

- **Documentation**
  - Added an entry to the changelog describing the improved error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->